### PR TITLE
Consider response code 403 as an error

### DIFF
--- a/gopherduty.go
+++ b/gopherduty.go
@@ -26,6 +26,7 @@ type PagerDuty struct {
 	MaxRetry          int    // Maximum API call retries. Defaults to 0.
 	RetryBaseInterval int    // Starting delay for a retry in seconds. Defaults to 10.
 	retries           int
+	endpoint          *string
 }
 
 // Convenience method to create a new PagerDuty struct.
@@ -64,7 +65,7 @@ func (p *PagerDuty) doRequest(eventType, incidentKey, description, client, clien
 		Details:     details,
 	}
 
-	response := request.submit()
+	response := request.submit(p.endpoint)
 	if response.HasErrors() && p.retries < p.MaxRetry {
 		p.delayRetry()
 		p.retries++

--- a/request.go
+++ b/request.go
@@ -2,13 +2,15 @@ package gopherduty
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
 )
 
-const endpoint = "https://events.pagerduty.com/generic/2010-04-15/create_event.json"
+const defaultEndpoint = "https://events.pagerduty.com/generic/2010-04-15/create_event.json"
 
 type pagerDutyRequest struct {
 	ServiceKey  string      `json:"service_key"`
@@ -20,13 +22,18 @@ type pagerDutyRequest struct {
 	Details     interface{} `json:"details"`
 }
 
-func (p *pagerDutyRequest) submit() (pagerResponse *PagerDutyResponse) {
+func (p *pagerDutyRequest) submit(alternateEndpoint *string) (pagerResponse *PagerDutyResponse) {
 	pagerResponse = &PagerDutyResponse{}
 
 	body, err := json.Marshal(p)
 	if err != nil {
 		pagerResponse.appendError(err)
 		return pagerResponse
+	}
+
+	endpoint := defaultEndpoint
+	if alternateEndpoint != nil {
+		endpoint = *alternateEndpoint
 	}
 
 	buf := bytes.NewBuffer(body)
@@ -43,6 +50,14 @@ func (p *pagerDutyRequest) submit() (pagerResponse *PagerDutyResponse) {
 	}
 
 	pagerResponse.parse(responseBody)
+
+	// PagerDuty sends a HTTP 403 when you have been rate-limited
+	// rate-limiting implies this current request has not been received.
+	if response.StatusCode == http.StatusForbidden {
+		errMsg := fmt.Sprintf("%v. %v", pagerResponse.Status, pagerResponse.Message)
+		pagerResponse.appendError(errors.New(errMsg))
+		return pagerResponse
+	}
 
 	return pagerResponse
 }


### PR DESCRIPTION
PagerDuty sends a 403 - Forbidden response code when the service key is
being rate-limited. The correct thing to do is to retry the request
after a delay - so treat this condition as if it were any other error.

Includes test of this behavior against a test server that only returns 403.
See [PagerDuty event v1 documentation](https://v2.developer.pagerduty.com/docs/trigger-events) for these details and recommendations.